### PR TITLE
Combine xml

### DIFF
--- a/csv_combine.py
+++ b/csv_combine.py
@@ -1,5 +1,7 @@
 import os
 import csv
+import sqlite3
+from typing import Iterator
 
 def combine_csv_files(file_paths, output_filename):
     combined_data = []
@@ -20,16 +22,35 @@ def combine_csv_files(file_paths, output_filename):
 
     print(f"Combined CSV files saved as {output_filename}")
 
+def get_ports(xml_path: str) -> Iterator[list]:
+    """
+    Retrieves port data from an nmap xml.
+    """
+    pass
+
+def list_files(file_path: str) -> set[str]:
+    """
+    Retrieves absolute path(s) for a given file or directory of xml files.
+    """
+    if os.path.isfile(file_path):
+        return set(os.path.abspath(file_path))
+    else:
+        return set([
+            os.path.abspath(f) 
+            for f in os.listdir(file_path)
+            if f.lower().endswith('.xml')
+        ])
+
 if __name__ == '__main__':
-    file_paths = []
+    file_paths = set()
     while True:
-        file_path = input("Enter the path of the CSV file to combine (or 'done' to finish): ")
+        file_path = input("Enter the path of the XML file or directory to combine (or 'done' to finish): ")
         if file_path.lower() == 'done':
             break
         if not os.path.exists(file_path):
-            print("File not found. Please enter a valid file path.")
+            print("File/dir not found. Please enter a valid file path.")
             continue
-        file_paths.append(file_path)
+        file_paths |= list_files(file_path)
 
     output_filename = input("Enter the filename for the combined CSV file: ")
     combine_csv_files(file_paths, output_filename)

--- a/csv_combine.py
+++ b/csv_combine.py
@@ -1,42 +1,107 @@
 import os
-import csv
 import sqlite3
+import secrets
+import string
+import xml.etree.ElementTree as ET
 from typing import Iterator
 
-def combine_csv_files(file_paths, output_filename):
-    combined_data = []
-    header = None
+class NmapDB:
+    """
+    A simple wrapper for db operations.
+    """
+    def __init__(self) -> None:
+        self.db_file = '/tmp/' + ''.join(
+            secrets.choice(string.ascii_letters + string.digits)
+            for _ in range(5)) + '.db'
+        self.con = sqlite3.connect(self.db_file)
+        self.cur = self.con.cursor()
+        self.cur.execute('''
+            CREATE TABLE open_ports(
+                o1 INT, o2 INT, o3 INT, o4 INT, port INT, hostname, os,
+                proto, service, product,
+                PRIMARY KEY (o1, o2, o3, o4, port))
+        ''')
 
-    for file_path in file_paths:
-        with open(file_path, 'r', newline='') as file:
-            reader = csv.reader(file)
-            data = list(reader)
-            if header is None:
-                header = data[0]
-                combined_data.append(header)
-            combined_data.extend(data[1:])
+    def __del__(self) -> None:
+        os.remove(self.db_file)
 
-    with open(output_filename, 'w', newline='') as output_file:
-        writer = csv.writer(output_file)
-        writer.writerows(combined_data)
+    def populate(self, data: dict) -> None:
+        """
+        Inserts a given port information into the database.
+        The IP is split into four columns for easy sorting.
+        """
+        octet = data['ip'].split('.')
+        for x in range(4):
+            data[f'o{x+1}'] = octet[x]
+        
+        self.cur.execute('''
+            INSERT OR IGNORE INTO open_ports VALUES(
+                :o1, :o2, :o3, :o4, :port, :hostname, :os,
+                :proto, :service, :product)
+        ''', data)
+        self.con.commit()
 
-    print(f"Combined CSV files saved as {output_filename}")
+    def dump_to_csv(self, output_file) -> None:
+        """
+        Sorts, appends a sort integer column, and saves results to the
+        given csv file.
+        """
+        select = '''
+            SELECT
+                ROW_NUMBER() OVER (
+                    ORDER BY o1, o2, o3, o4, port
+                ) AS Sort,
+                o1 || '.' || o2 || '.' || o3 || '.' || o4 AS IP,
+                '' AS Technology,
+                '' AS Findings,
+                '' AS Notes,
+                port AS Port,
+                service AS Service,
+                hostname AS Host,
+                os AS OS,
+                proto AS Proto,
+                product AS Product
+            FROM open_ports
+        '''
+        os.system(f'sqlite3 -header -csv {self.db_file} "{select}" \
+                  > {output_file}')
 
-def get_ports(xml_path: str) -> Iterator[list]:
+def get_ports(xml_path: str) -> Iterator[dict]:
     """
     Retrieves port data from an nmap xml.
     """
-    pass
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    for host in root.findall('host/status[@state="up"]/..'):
+        ip = host.find('address[@addrtype="ipv4"]').get('addr')
+        el_host = host.find('hostnames/hostname[@name]')
+        hostname = el_host.get('name') if el_host else ''
+        el_os = host.find('os/osmatch')
+        osname = el_os.get('name') if el_os else ''
+
+        for port in host.findall('ports/port/state[@state="open"]/..'):
+            el_srv = port.find('service')
+            
+            yield {
+                'ip': ip,
+                'hostname': hostname,
+                'os': osname,
+                'port': port.get('portid'),
+                'proto': port.get('protocol'),
+                'service': el_srv.get('name') if el_srv else '',
+                'product': el_srv.get('product') if el_srv else ''
+            }
 
 def list_files(file_path: str) -> set[str]:
     """
     Retrieves absolute path(s) for a given file or directory of xml files.
     """
     if os.path.isfile(file_path):
-        return set(os.path.abspath(file_path))
+        return {os.path.abspath(file_path)}
     else:
         return set([
-            os.path.abspath(f) 
+            os.path.abspath(os.path.join(file_path, f))
             for f in os.listdir(file_path)
             if f.lower().endswith('.xml')
         ])
@@ -53,4 +118,9 @@ if __name__ == '__main__':
         file_paths |= list_files(file_path)
 
     output_filename = input("Enter the filename for the combined CSV file: ")
-    combine_csv_files(file_paths, output_filename)
+
+    db = NmapDB()
+    for xml_file in file_paths:
+        for port in get_ports(xml_file):
+            db.populate(port)
+    db.dump_to_csv(output_filename)


### PR DESCRIPTION
Instead of working on CSV files, the script now takes paths to XML nmap results (a directory may also be provided which will pull all immediate .xml files), combines the results in a way that silently discards duplicate IP-port entries, and dumps the results to a CSV file. Other minor change is treating `file_paths` as a set to avoid explicitly checking for potential duplicates.